### PR TITLE
fix: resolve all compiler warnings in MoonBit code

### DIFF
--- a/src/lib/app.mbt
+++ b/src/lib/app.mbt
@@ -7,7 +7,7 @@ pub(all) struct RespoApp[Model] {
 
 ///| backup store to local storage before unload
 pub fn[Model : ToJson] backup_model_beforeunload(
-  self : RespoApp[Model]
+  self : RespoApp[Model],
 ) -> Unit {
   let window = @dom_ffi.window()
   let storage = window.local_storage()
@@ -23,7 +23,7 @@ pub fn[Model : ToJson] backup_model_beforeunload(
 
 ///|
 pub fn[Model : @json.FromJson + Default] try_load_storage(
-  key : String
+  key : String,
 ) -> Model {
   let window = @dom_ffi.window()
   let storage = window.local_storage()
@@ -54,7 +54,7 @@ pub fn[Model : @json.FromJson + Default] try_load_storage(
 pub fn[Model, ActionOp] RespoApp::render_loop(
   self : RespoApp[Model],
   renderer : () -> @node.RespoNode[ActionOp] raise @node.RespoCommonError,
-  dispatch_action : (ActionOp) -> Unit raise @node.RespoCommonError
+  dispatch_action : (ActionOp) -> Unit raise @node.RespoCommonError,
 ) -> Unit {
   let mount_target = self.mount_target
   let ret = try? render_node(

--- a/src/lib/dialog/alert.mbt
+++ b/src/lib/dialog/alert.mbt
@@ -38,7 +38,7 @@ fn[T] comp_alert_modal(
   options~ : AlertOptions,
   show~ : Bool,
   on_read~ : (@node.DispatchFn[T]) -> Unit,
-  on_close~ : (@node.DispatchFn[T]) -> Unit
+  on_close~ : (@node.DispatchFn[T]) -> Unit,
 ) -> @node.RespoNode[T] {
   let effect_focus_data : EffectFocus = { show, }
   let effect_modal_fade_data : EffectModalFade = { show, }
@@ -118,7 +118,7 @@ pub(all) struct AlertPlugin[T] {
 
 ///|
 pub fn[T : @node.RespoAction] render(
-  self : AlertPlugin[T]
+  self : AlertPlugin[T],
 ) -> @node.RespoNode[T] {
   let on_read = self.on_read
   let state = self.state
@@ -170,7 +170,7 @@ pub fn[T : @node.RespoAction] render(
 pub fn[T : @node.RespoAction] show(
   self : AlertPlugin[T],
   dispatch : @node.DispatchFn[T],
-  text : String?
+  text : String?,
 ) -> Unit raise @node.RespoCommonError {
   dispatch.set_state(self.cursor, { show: true, text })
 }
@@ -178,7 +178,7 @@ pub fn[T : @node.RespoAction] show(
 ///|
 pub fn[T : @node.RespoAction] close(
   self : AlertPlugin[T],
-  dispatch : @node.DispatchFn[T]
+  dispatch : @node.DispatchFn[T],
 ) -> Unit {
   let ret = try? dispatch.set_state(self.cursor, {
       show: false,
@@ -193,7 +193,7 @@ pub fn[T : @node.RespoAction] close(
 pub fn[T] AlertPlugin::new(
   states : RespoStatesTree,
   options : AlertOptions,
-  on_read : (@node.DispatchFn[T]) -> Unit
+  on_read : (@node.DispatchFn[T]) -> Unit,
 ) -> AlertPlugin[T] {
   let instance : AlertPlugin[T] = {
     state: states.cast_branch(),

--- a/src/lib/dialog/confirm.mbt
+++ b/src/lib/dialog/confirm.mbt
@@ -27,7 +27,7 @@ fn[T] comp_confirm_modal(
   options : ConfirmOptions,
   show : Bool,
   on_confirm~ : (@node.DispatchFn[T]) -> Unit,
-  on_close~ : (@node.DispatchFn[T]) -> Unit
+  on_close~ : (@node.DispatchFn[T]) -> Unit,
 ) -> @node.RespoNode[T] {
 
   // effect 1
@@ -109,7 +109,7 @@ pub(all) struct ConfirmPlugin[T] {
 
 ///|
 pub fn[T : @node.RespoAction] ConfirmPlugin::render(
-  self : ConfirmPlugin[T]
+  self : ConfirmPlugin[T],
 ) -> @node.RespoNode[T] {
   let on_confirm = self.on_confirm
   comp_confirm_modal(
@@ -151,7 +151,7 @@ pub fn[T : @node.RespoAction] ConfirmPlugin::render(
 pub fn[T : @node.RespoAction] ConfirmPlugin::show(
   self : ConfirmPlugin[T],
   dispatch : @node.DispatchFn[T],
-  next_task : () -> Unit
+  next_task : () -> Unit,
 ) -> Unit raise @node.RespoCommonError {
   let window = @dom_ffi.window()
   window.dirty_set_fn(next_task_name, next_task)
@@ -162,7 +162,7 @@ pub fn[T : @node.RespoAction] ConfirmPlugin::show(
 pub fn[T] ConfirmPlugin::new(
   states : RespoStatesTree,
   options : ConfirmOptions,
-  on_confirm : (@node.DispatchFn[T]) -> Unit
+  on_confirm : (@node.DispatchFn[T]) -> Unit,
 ) -> ConfirmPlugin[T] {
   let instance : ConfirmPlugin[T] = {
     state: states.cast_branch(),

--- a/src/lib/dialog/dialogs.mbt
+++ b/src/lib/dialog/dialogs.mbt
@@ -163,7 +163,7 @@ let temp_listener : String = "temp_listener"
 ///| handle global keydown event
 pub fn[T] comp_esc_listener(
   _show : Bool,
-  on_close~ : (@node.DispatchFn[T]) -> Unit
+  on_close~ : (@node.DispatchFn[T]) -> Unit,
 ) -> @node.RespoNode[T] {
   let effect_modal_close_data = EffectModalClose::default()
   @node.RespoComponent::named(
@@ -171,7 +171,7 @@ pub fn[T] comp_esc_listener(
     effects=[effect_modal_close_data],
     input(value="", style=respo_style(display=None), on_keydown=fn(
       e,
-      dispatch
+      dispatch,
     ) {
       if e is Keyboard(key~, ..) && key == "Escape" {
         on_close(dispatch)

--- a/src/lib/dialog/drawer.mbt
+++ b/src/lib/dialog/drawer.mbt
@@ -12,9 +12,11 @@ pub(all) struct DrawerOptions[T] {
 } derive(Default)
 
 ///|
-struct DrawerRenderer[T]((
-  (@node.DispatchFn[T]) -> Unit raise @node.RespoCommonError,
-) -> @node.RespoNode[T] raise @node.RespoCommonError)
+struct DrawerRenderer[T](
+  ((@node.DispatchFn[T]) -> Unit raise @node.RespoCommonError) -> @node.RespoNode[
+    T,
+  ] raise @node.RespoCommonError
+)
 
 ///|
 impl[T] Show for DrawerRenderer[T] with output(self, logger) {

--- a/src/lib/dialog/drawer.mbt
+++ b/src/lib/dialog/drawer.mbt
@@ -12,9 +12,9 @@ pub(all) struct DrawerOptions[T] {
 } derive(Default)
 
 ///|
-type DrawerRenderer[T] (
+struct DrawerRenderer[T]((
   (@node.DispatchFn[T]) -> Unit raise @node.RespoCommonError,
-) -> @node.RespoNode[T] raise @node.RespoCommonError
+) -> @node.RespoNode[T] raise @node.RespoCommonError)
 
 ///|
 impl[T] Show for DrawerRenderer[T] with output(self, logger) {
@@ -30,7 +30,7 @@ pub impl[T] Default for DrawerRenderer[T] with default() -> DrawerRenderer[T] {
 pub fn[T] DrawerRenderer::new(
   renderer : ((@node.DispatchFn[T]) -> Unit raise @node.RespoCommonError) -> @node.RespoNode[
     T,
-  ] raise @node.RespoCommonError
+  ] raise @node.RespoCommonError,
 ) -> DrawerRenderer[T] {
   renderer
 }
@@ -38,7 +38,7 @@ pub fn[T] DrawerRenderer::new(
 ///|
 fn[T] run(
   self : DrawerRenderer[T],
-  close : (@node.DispatchFn[T]) -> Unit raise @node.RespoCommonError
+  close : (@node.DispatchFn[T]) -> Unit raise @node.RespoCommonError,
 ) -> @node.RespoNode[T] raise @node.RespoCommonError {
   let f = self.inner()
   f(close)
@@ -48,7 +48,7 @@ fn[T] run(
 fn[T] comp_drawer(
   options~ : DrawerOptions[T],
   show~ : Bool,
-  on_close~ : (@node.DispatchFn[T]) -> Unit
+  on_close~ : (@node.DispatchFn[T]) -> Unit,
 ) -> @node.RespoNode[T] raise @node.RespoCommonError {
   let effect_focus_data : EffectFocus = { show, }
   let effect_drawer_fade_data : EffectDrawerFade = { show, }
@@ -118,10 +118,10 @@ pub(all) struct DrawerPlugin[T] {
 
 ///|
 pub fn[T : @node.RespoAction] DrawerPlugin::render(
-  self : DrawerPlugin[T]
+  self : DrawerPlugin[T],
 ) -> @node.RespoNode[T] raise @node.RespoCommonError {
   comp_drawer(options=self.options, show=self.state.show, on_close=fn(
-    dispatch
+    dispatch,
   ) {
     let ret = try? dispatch.set_state(self.cursor, { show: false })
     match ret {
@@ -134,7 +134,7 @@ pub fn[T : @node.RespoAction] DrawerPlugin::render(
 ///|
 pub fn[T : @node.RespoAction] DrawerPlugin::show(
   self : DrawerPlugin[T],
-  dispatch : @node.DispatchFn[T]
+  dispatch : @node.DispatchFn[T],
 ) -> Unit raise @node.RespoCommonError {
   dispatch.set_state(self.cursor, { show: true })
 }
@@ -142,7 +142,7 @@ pub fn[T : @node.RespoAction] DrawerPlugin::show(
 ///|
 pub fn[T : @node.RespoAction] DrawerPlugin::close(
   self : DrawerPlugin[T],
-  dispatch : @node.DispatchFn[T]
+  dispatch : @node.DispatchFn[T],
 ) -> Unit raise @node.RespoCommonError {
   dispatch.set_state(self.cursor, { show: false })
 }
@@ -150,7 +150,7 @@ pub fn[T : @node.RespoAction] DrawerPlugin::close(
 ///|
 pub fn[T] DrawerPlugin::new(
   states : RespoStatesTree,
-  options : DrawerOptions[T]
+  options : DrawerOptions[T],
 ) -> DrawerPlugin[T] {
   let cursor = states.path()
   { state: states.cast_branch(), options, cursor }

--- a/src/lib/dialog/modal.mbt
+++ b/src/lib/dialog/modal.mbt
@@ -14,9 +14,9 @@ pub(all) struct ModalOptions[T] {
 ///| tmp fix since syntax error
 
 ///|
-pub(all) type ModalRenderer[T] (
+pub(all) struct ModalRenderer[T]((
   (@node.DispatchFn[T]) -> Unit raise @node.RespoCommonError,
-) -> @node.RespoNode[T] raise @node.RespoCommonError
+) -> @node.RespoNode[T] raise @node.RespoCommonError)
 
 ///|
 pub impl[T] Default for ModalRenderer[T] with default() -> ModalRenderer[T] {
@@ -27,7 +27,7 @@ pub impl[T] Default for ModalRenderer[T] with default() -> ModalRenderer[T] {
 pub fn[T] ModalRenderer::new(
   renderer : ((@node.DispatchFn[T]) -> Unit raise @node.RespoCommonError) -> @node.RespoNode[
     T,
-  ] raise @node.RespoCommonError
+  ] raise @node.RespoCommonError,
 ) -> ModalRenderer[T] {
   renderer
 }
@@ -36,7 +36,7 @@ pub fn[T] ModalRenderer::new(
 fn[T] comp_modal(
   options : ModalOptions[T],
   show : Bool,
-  on_close : (@node.DispatchFn[T]) -> Unit
+  on_close : (@node.DispatchFn[T]) -> Unit,
 ) -> @node.RespoNode[T] raise @node.RespoCommonError {
   // let effect_focus_data : EffectFocus = { show, }
   let effect_modal_fade_data : EffectModalFade = { show, }
@@ -116,7 +116,7 @@ pub(all) struct ModalPlugin[T] {
 
 ///|
 pub fn[T : @node.RespoAction] ModalPlugin::render(
-  self : ModalPlugin[T]
+  self : ModalPlugin[T],
 ) -> @node.RespoNode[T] raise @node.RespoCommonError {
   comp_modal(self.options, self.state.show, dispatch => match
     (try? dispatch.set_state(self.cursor, { show: false })) {
@@ -128,7 +128,7 @@ pub fn[T : @node.RespoAction] ModalPlugin::render(
 ///|
 pub fn[T : @node.RespoAction] ModalPlugin::show(
   self : ModalPlugin[T],
-  dispatch : @node.DispatchFn[T]
+  dispatch : @node.DispatchFn[T],
 ) -> Unit raise @node.RespoCommonError {
   dispatch.set_state(self.cursor, { show: true })
 }
@@ -136,7 +136,7 @@ pub fn[T : @node.RespoAction] ModalPlugin::show(
 ///|
 pub fn[T : @node.RespoAction] ModalPlugin::close(
   self : ModalPlugin[T],
-  dispatch : @node.DispatchFn[T]
+  dispatch : @node.DispatchFn[T],
 ) -> Unit raise @node.RespoCommonError {
   dispatch.set_state(self.cursor, { show: false })
 }
@@ -144,7 +144,7 @@ pub fn[T : @node.RespoAction] ModalPlugin::close(
 ///|
 pub fn[T] ModalPlugin::new(
   states : RespoStatesTree,
-  options : ModalOptions[T]
+  options : ModalOptions[T],
 ) -> ModalPlugin[T] {
   { state: states.cast_branch(), options, cursor: states.path() }
 }

--- a/src/lib/dialog/modal.mbt
+++ b/src/lib/dialog/modal.mbt
@@ -14,9 +14,11 @@ pub(all) struct ModalOptions[T] {
 ///| tmp fix since syntax error
 
 ///|
-pub(all) struct ModalRenderer[T]((
-  (@node.DispatchFn[T]) -> Unit raise @node.RespoCommonError,
-) -> @node.RespoNode[T] raise @node.RespoCommonError)
+pub(all) struct ModalRenderer[T](
+  ((@node.DispatchFn[T]) -> Unit raise @node.RespoCommonError) -> @node.RespoNode[
+    T,
+  ] raise @node.RespoCommonError
+)
 
 ///|
 pub impl[T] Default for ModalRenderer[T] with default() -> ModalRenderer[T] {

--- a/src/lib/dialog/prompt.mbt
+++ b/src/lib/dialog/prompt.mbt
@@ -23,7 +23,7 @@ pub(all) struct PromptOptions {
 } derive(Default)
 
 ///|
-pub(all) type PromptValidator (String) -> Result[Unit, String]
+pub(all) struct PromptValidator((String) -> Result[Unit, String])
 
 ///|
 impl Show for PromptValidator with output(self, logger) {
@@ -32,7 +32,7 @@ impl Show for PromptValidator with output(self, logger) {
 
 ///|
 pub fn PromptValidator::new(
-  f : (String) -> Result[Unit, String]
+  f : (String) -> Result[Unit, String],
 ) -> PromptValidator {
   f
 }
@@ -40,7 +40,7 @@ pub fn PromptValidator::new(
 ///|
 fn PromptValidator::run(
   self : PromptValidator,
-  value : String
+  value : String,
 ) -> Result[Unit, String] {
   let f = self.inner()
   f(value)
@@ -60,7 +60,7 @@ fn[T : @node.RespoAction] comp_prompt_modal(
   options~ : PromptOptions,
   show~ : Bool,
   on_submit~ : (String, @node.DispatchFn[T]) -> Unit raise @node.RespoCommonError,
-  on_close~ : (@node.DispatchFn[T]) -> Unit
+  on_close~ : (@node.DispatchFn[T]) -> Unit,
 ) -> @node.RespoNode[T] {
   let cursor = (states.path() : @node.RespoCursor[InputState])
   // TODO need compare with old
@@ -77,7 +77,7 @@ fn[T : @node.RespoAction] comp_prompt_modal(
   // )
   let on_text_input = fn(
     e : @node.RespoEvent,
-    dispatch : @node.DispatchFn[T]
+    dispatch : @node.DispatchFn[T],
   ) -> Unit raise @node.RespoCommonError {
     if e is Input(value~, ..) {
       // @dom_ffi.log("input value: " + value.escape())
@@ -87,7 +87,7 @@ fn[T : @node.RespoAction] comp_prompt_modal(
   }
   let check_submit = fn(
     text : String,
-    dispatch : @node.DispatchFn[T]
+    dispatch : @node.DispatchFn[T],
   ) -> Unit raise @node.RespoCommonError {
     @dom_ffi.log("Event states tree: " + states.to_json().stringify(indent=2))
     match options.validator {
@@ -229,7 +229,7 @@ pub(all) struct PromptPlugin[T] {
 
 ///|
 pub fn[T : @node.RespoAction] PromptPlugin::render(
-  self : PromptPlugin[T]
+  self : PromptPlugin[T],
 ) -> @node.RespoNode[T] {
   let on_submit = self.on_submit
   comp_prompt_modal(
@@ -262,7 +262,7 @@ pub fn[T : @node.RespoAction] PromptPlugin::render(
 pub fn[T : @node.RespoAction] PromptPlugin::show(
   self : PromptPlugin[T],
   dispatch : @node.DispatchFn[T],
-  next_task : (String) -> Unit
+  next_task : (String) -> Unit,
 ) -> Unit raise @node.RespoCommonError {
   let window = @dom_ffi.window()
   window.dirty_set_fn_1(next_prompt_task_name, next_task)
@@ -272,7 +272,7 @@ pub fn[T : @node.RespoAction] PromptPlugin::show(
 ///|
 pub fn[T : @node.RespoAction] PromptPlugin::close(
   self : PromptPlugin[T],
-  dispatch : @node.DispatchFn[T]
+  dispatch : @node.DispatchFn[T],
 ) -> Unit raise @node.RespoCommonError {
   dispatch.set_state(self.cursor, { show: false, text: self.text })
 }
@@ -281,7 +281,7 @@ pub fn[T : @node.RespoAction] PromptPlugin::close(
 pub fn[T] PromptPlugin::new(
   states : RespoStatesTree,
   options : PromptOptions,
-  on_submit : (String, @node.DispatchFn[T]) -> Unit raise @node.RespoCommonError
+  on_submit : (String, @node.DispatchFn[T]) -> Unit raise @node.RespoCommonError,
 ) -> PromptPlugin[T] {
   {
     states,

--- a/src/lib/memo_once.mbt
+++ b/src/lib/memo_once.mbt
@@ -46,7 +46,7 @@ pub fn[K1 : Eq, K2 : Eq, V] memo_once2(f : (K1, K2) -> V) -> (K1, K2) -> V {
 
 ///| Memoize a function with a single cache slot, taking three arguments.
 pub fn[K1 : Eq, K2 : Eq, K3 : Eq, V] memo_once3(
-  f : (K1, K2, K3) -> V
+  f : (K1, K2, K3) -> V,
 ) -> (K1, K2, K3) -> V {
   let mut cache : ((K1, K2, K3), V)? = None
   fn(k1 : K1, k2 : K2, k3 : K3) -> V {
@@ -70,7 +70,7 @@ pub fn[K1 : Eq, K2 : Eq, K3 : Eq, V] memo_once3(
 
 ///| Memoize a function with a single cache slot, taking four arguments.
 pub fn[K1 : Eq, K2 : Eq, K3 : Eq, K4 : Eq, V] memo_once4(
-  f : (K1, K2, K3, K4) -> V
+  f : (K1, K2, K3, K4) -> V,
 ) -> (K1, K2, K3, K4) -> V {
   let mut cache : ((K1, K2, K3, K4), V)? = None
   fn(k1 : K1, k2 : K2, k3 : K3, k4 : K4) -> V {
@@ -94,7 +94,7 @@ pub fn[K1 : Eq, K2 : Eq, K3 : Eq, K4 : Eq, V] memo_once4(
 
 ///| Memoize a function with a single cache slot, taking five arguments.
 pub fn[K1 : Eq, K2 : Eq, K3 : Eq, K4 : Eq, K5 : Eq, V] memo_once5(
-  f : (K1, K2, K3, K4, K5) -> V
+  f : (K1, K2, K3, K4, K5) -> V,
 ) -> (K1, K2, K3, K4, K5) -> V {
   let mut cache : ((K1, K2, K3, K4, K5), V)? = None
   fn(k1 : K1, k2 : K2, k3 : K3, k4 : K4, k5 : K5) -> V {

--- a/src/lib/memoize.mbt
+++ b/src/lib/memoize.mbt
@@ -17,7 +17,7 @@ pub fn[K : Hash + Eq, V] memoize1(f : (K) -> V) -> (K) -> V {
 
 ///|
 pub fn[K1 : Hash + Eq, K2 : Hash + Eq, V] memoize2(
-  f : (K1, K2) -> V
+  f : (K1, K2) -> V,
 ) -> (K1, K2) -> V {
   let map = @hashmap.new()
   fn(k1 : K1, k2 : K2) -> V {
@@ -34,7 +34,7 @@ pub fn[K1 : Hash + Eq, K2 : Hash + Eq, V] memoize2(
 
 ///|
 pub fn[K1 : Hash + Eq, K2 : Hash + Eq, K3 : Hash + Eq, V] memoize3(
-  f : (K1, K2, K3) -> V
+  f : (K1, K2, K3) -> V,
 ) -> (K1, K2, K3) -> V {
   let map = @hashmap.new()
   fn(k1 : K1, k2 : K2, k3 : K3) -> V {
@@ -51,7 +51,7 @@ pub fn[K1 : Hash + Eq, K2 : Hash + Eq, K3 : Hash + Eq, V] memoize3(
 
 ///|
 pub fn[K1 : Hash + Eq, K2 : Hash + Eq, K3 : Hash + Eq, K4 : Hash + Eq, V] memoize4(
-  f : (K1, K2, K3, K4) -> V
+  f : (K1, K2, K3, K4) -> V,
 ) -> (K1, K2, K3, K4) -> V {
   let map = @hashmap.new()
   fn(k1 : K1, k2 : K2, k3 : K3, k4 : K4) -> V {
@@ -67,8 +67,15 @@ pub fn[K1 : Hash + Eq, K2 : Hash + Eq, K3 : Hash + Eq, K4 : Hash + Eq, V] memoiz
 }
 
 ///|
-pub fn[K1 : Hash + Eq, K2 : Hash + Eq, K3 : Hash + Eq, K4 : Hash + Eq, K5 : Hash + Eq, V] memoize5(
-  f : (K1, K2, K3, K4, K5) -> V
+pub fn[
+  K1 : Hash + Eq,
+  K2 : Hash + Eq,
+  K3 : Hash + Eq,
+  K4 : Hash + Eq,
+  K5 : Hash + Eq,
+  V,
+] memoize5(
+  f : (K1, K2, K3, K4, K5) -> V,
 ) -> (K1, K2, K3, K4, K5) -> V {
   let map = @hashmap.new()
   fn(k1 : K1, k2 : K2, k3 : K3, k4 : K4, k5 : K5) -> V {

--- a/src/lib/node/alias.mbt
+++ b/src/lib/node/alias.mbt
@@ -10,7 +10,7 @@ pub fn[T] div(
   style~ : RespoStyle = respo_style(),
   children : Array[RespoNode[T]],
   innerHTML? : String,
-  on_click? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError
+  on_click? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -64,7 +64,7 @@ pub fn[T] div_listed(
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
   style~ : RespoStyle = respo_style(),
-  children : Array[(RespoIndexKey, RespoNode[T])]
+  children : Array[(RespoIndexKey, RespoNode[T])],
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -85,7 +85,7 @@ pub fn[T] span(
   ] = {},
   style~ : RespoStyle = respo_style(),
   children : Array[RespoNode[T]],
-  on_click? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError
+  on_click? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -115,7 +115,7 @@ pub fn[T] text_node(
   class_name? : String,
   class_list~ : Array[String] = [],
   style? : RespoStyle,
-  text : String
+  text : String,
 ) -> RespoNode[T] {
   span(
     inner_text=text,
@@ -137,7 +137,7 @@ pub fn[T] button(
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
   style~ : RespoStyle = respo_style(),
-  on_click? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError
+  on_click? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -173,7 +173,7 @@ pub fn[T] input(
   on_keyup? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   on_keypress? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   on_focus? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
-  on_blur? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError
+  on_blur? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -260,7 +260,7 @@ pub fn[T] textarea(
   on_keyup? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   on_keypress? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   on_focus? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
-  on_blur? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError
+  on_blur? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -358,7 +358,7 @@ pub fn[T] a(
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
   style~ : RespoStyle = respo_style(),
-  children? : Array[RespoNode[T]]
+  children? : Array[RespoNode[T]],
 ) -> RespoNode[T] {
   attrs.set("href", href)
   if inner_text is Some(inner_text) {
@@ -389,7 +389,7 @@ pub fn[T] br(
     RespoEventType,
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
-  style~ : RespoStyle = respo_style()
+  style~ : RespoStyle = respo_style(),
 ) -> RespoNode[T] {
   Element({ name: "br", attrs, event, style, children: [] })
 }
@@ -407,7 +407,7 @@ pub fn[T] i(
   ] = {},
   style~ : RespoStyle = respo_style(),
   children : Array[RespoNode[T]],
-  on_click? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError
+  on_click? : (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -444,7 +444,7 @@ pub fn[T] b(
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
   style~ : RespoStyle = respo_style(),
-  children : Array[RespoNode[T]]
+  children : Array[RespoNode[T]],
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -485,7 +485,7 @@ pub fn[T] iframe(
     RespoEventType,
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
-  style~ : RespoStyle = respo_style()
+  style~ : RespoStyle = respo_style(),
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -520,7 +520,7 @@ pub fn[T] canvas(
     RespoEventType,
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
-  style~ : RespoStyle = respo_style()
+  style~ : RespoStyle = respo_style(),
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -544,7 +544,7 @@ pub fn[T] code(
     RespoEventType,
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
-  style~ : RespoStyle = respo_style()
+  style~ : RespoStyle = respo_style(),
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -565,7 +565,7 @@ pub fn[T] pre(
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
   style~ : RespoStyle = respo_style(),
-  children? : Array[RespoNode[T]]
+  children? : Array[RespoNode[T]],
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -589,7 +589,7 @@ pub fn[T] p(
   inner_text~ : String,
   attrs~ : Map[String, String] = {},
   style~ : RespoStyle = respo_style(),
-  children : Array[RespoNode[T]]
+  children : Array[RespoNode[T]],
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -608,7 +608,7 @@ pub fn[T] blockquote(
   inner_text? : String,
   attrs~ : Map[String, String] = {},
   style~ : RespoStyle = respo_style(),
-  children : Array[RespoNode[T]]
+  children : Array[RespoNode[T]],
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -650,7 +650,7 @@ pub fn[T] img(
     RespoEventType,
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
-  style~ : RespoStyle = respo_style()
+  style~ : RespoStyle = respo_style(),
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -690,7 +690,7 @@ pub fn[T] video(
     RespoEventType,
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
-  style~ : RespoStyle = respo_style()
+  style~ : RespoStyle = respo_style(),
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -730,7 +730,7 @@ pub fn[T] h1(
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
   style~ : RespoStyle = respo_style(),
-  children : Array[RespoNode[T]]
+  children : Array[RespoNode[T]],
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -764,7 +764,7 @@ pub fn[T] h2(
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
   style~ : RespoStyle = respo_style(),
-  children : Array[RespoNode[T]]
+  children : Array[RespoNode[T]],
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -798,7 +798,7 @@ pub fn[T] h3(
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
   style~ : RespoStyle = respo_style(),
-  children : Array[RespoNode[T]]
+  children : Array[RespoNode[T]],
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -832,7 +832,7 @@ pub fn[T] h4(
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
   style~ : RespoStyle = respo_style(),
-  children : Array[RespoNode[T]]
+  children : Array[RespoNode[T]],
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -866,7 +866,7 @@ pub fn[T] h5(
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
   style~ : RespoStyle = respo_style(),
-  children : Array[RespoNode[T]]
+  children : Array[RespoNode[T]],
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -900,7 +900,7 @@ pub fn[T] h6(
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
   style~ : RespoStyle = respo_style(),
-  children : Array[RespoNode[T]]
+  children : Array[RespoNode[T]],
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -933,7 +933,7 @@ pub fn[T] li(
   ] = {},
   style~ : RespoStyle = respo_style(),
   children : Array[RespoNode[T]],
-  innerHTML? : String
+  innerHTML? : String,
 ) -> RespoNode[T] {
   if combile_classes(class_name, class_list) is Some(class_name) {
     attrs.set("class", class_name)
@@ -957,7 +957,7 @@ pub fn[T] space(
   width~ : Float = 1,
   height~ : Float = 1,
   class_name? : String,
-  class_list~ : Array[String] = []
+  class_list~ : Array[String] = [],
 ) -> RespoNode[T] {
   let attrs : Map[String, String] = {}
   if combile_classes(class_name, class_list) is Some(class_name) {
@@ -983,7 +983,7 @@ pub fn[T] create_element(
     (RespoEvent, DispatchFn[T]) -> Unit raise RespoCommonError,
   ] = {},
   style~ : RespoStyle = respo_style(),
-  children : Array[RespoNode[T]]
+  children : Array[RespoNode[T]],
 ) -> RespoNode[T] {
   Element({
     name,

--- a/src/lib/node/component.mbt
+++ b/src/lib/node/component.mbt
@@ -8,7 +8,7 @@ pub(all) struct RespoComponent[T] {
 ///|
 pub impl[T] Eq for RespoComponent[T] with op_equal(
   self : RespoComponent[T],
-  other : RespoComponent[T]
+  other : RespoComponent[T],
 ) -> Bool {
   if self.name != other.name {
     return false
@@ -32,7 +32,7 @@ impl[T] Show for RespoComponent[T] with output(self, logger) {
 pub fn[T] RespoComponent::named(
   name : String,
   tree : RespoNode[T],
-  effects~ : Array[&RespoEffect] = []
+  effects~ : Array[&RespoEffect] = [],
 ) -> RespoComponent[T] {
   { name, effects: effects.map(fn(x) { x.build_effect() }), tree }
 }

--- a/src/lib/node/css.mbt
+++ b/src/lib/node/css.mbt
@@ -1,5 +1,5 @@
 ///| use `respo_style` to create style, use `.add()` to add custom styles
-pub(all) type RespoStyle Array[(String, String)] derive(Eq, Default)
+pub(all) struct RespoStyle(Array[(String, String)]) derive(Eq, Default)
 
 // is_empty
 
@@ -116,7 +116,7 @@ pub fn respo_style(
   filter? : CssFilter,
   object_fit? : CssObjectFit,
   overscroll_behavior_x? : CssOverscrollBehavior,
-  overscroll_behavior_y? : CssOverscrollBehavior
+  overscroll_behavior_y? : CssOverscrollBehavior,
 ) -> RespoStyle {
   let style : Array[(String, String)] = []
   match color {
@@ -731,7 +731,7 @@ pub impl Show for CssBorder with output(self, logger) {
 pub fn CssBorder::new(
   width~ : Float = 1.0,
   style~ : CssBorderStyle = Solid,
-  color~ : CssColor = Black
+  color~ : CssColor = Black,
 ) -> CssBorder {
   (width, style, color)
 }
@@ -1105,10 +1105,11 @@ pub impl Show for CssOverscrollBehavior with output(self, logger) {
 let class_name_in_tags : @hashset.T[String] = @hashset.new()
 
 ///| use `static_style` instead
+#callsite(autofill(loc))
 #deprecated
 pub fn[U : Show] declare_static_style(
   rules : Array[(U, RespoStyle)],
-  loc~ : SourceLoc = _
+  loc~ : SourceLoc,
 ) -> String {
   static_style(rules, loc~)
 }
@@ -1119,9 +1120,10 @@ pub fn[U : Show] declare_static_style(
 ///  [("&", respo_style(margin=4 |> Px, background_color=Hsl(200, 90, 96)))],
 /// )
 /// ```
+#callsite(autofill(loc))
 pub fn[U : Show] static_style(
   rules : Array[(U, RespoStyle)],
-  loc~ : SourceLoc = _
+  loc~ : SourceLoc,
 ) -> String {
   // @dom_ffi.warn_log("SourceLoc" + loc.to_string())
   let gen_name = loc
@@ -1163,10 +1165,11 @@ pub fn[U : Show] static_style(
 }
 
 ///| use `contained_static_style` instead
+#callsite(autofill(loc))
 #deprecated
 pub fn[U : Show] declare_contained_style(
   rules : Array[(String?, U, RespoStyle)],
-  loc~ : SourceLoc = _
+  loc~ : SourceLoc,
 ) -> String {
   contained_static_style(rules, loc~)
 }
@@ -1177,9 +1180,10 @@ pub fn[U : Show] declare_contained_style(
 ///  [(Some("@media only screen and (max-width: 600px)"), "&", respo_style(margin=4 |> Px, background_color=Hsl(200, 90, 96)))],
 /// )
 /// ```
+#callsite(autofill(loc))
 pub fn[U : Show] contained_static_style(
   rules : Array[(String?, U, RespoStyle)],
-  loc~ : SourceLoc = _
+  loc~ : SourceLoc,
 ) -> String {
   // @dom_ffi.warn_log("SourceLoc" + loc.to_string())
   let gen_name = loc

--- a/src/lib/node/css.mbt
+++ b/src/lib/node/css.mbt
@@ -718,7 +718,7 @@ pub impl Show for CssBorderStyle with output(self, logger) {
 }
 
 ///|
-pub(all) type CssBorder (Float, CssBorderStyle, CssColor)
+pub(all) struct CssBorder((Float, CssBorderStyle, CssColor))
 
 ///|
 pub impl Show for CssBorder with output(self, logger) {

--- a/src/lib/node/diff.mbt
+++ b/src/lib/node/diff.mbt
@@ -4,7 +4,7 @@ pub fn[T] diff_tree(
   old_tree : RespoNode[T],
   coord : @immut/array.T[RespoCoord],
   dom_path : @immut/array.T[UInt],
-  changes : Ref[Array[DomChange[T]]]
+  changes : Ref[Array[DomChange[T]]],
 ) -> Unit raise RespoCommonError {
   if physical_equal(new_tree, old_tree) {
     return
@@ -131,7 +131,7 @@ fn[T] diff_attrs(
   coord : @immut/array.T[RespoCoord],
   dom_path : @immut/array.T[UInt],
   changes : Ref[Array[DomChange[T]]],
-  reset_inner : Ref[Bool]
+  reset_inner : Ref[Bool],
 ) -> Unit {
   let added : Map[String, String] = {}
   let removed : @hashset.T[String] = @hashset.new()
@@ -176,7 +176,7 @@ fn[T] diff_style(
   old_style : Map[String, String],
   coord : @immut/array.T[RespoCoord],
   dom_path : @immut/array.T[UInt],
-  changes : Ref[Array[DomChange[T]]]
+  changes : Ref[Array[DomChange[T]]],
 ) -> Unit {
   let added : Map[String, String] = {}
   let removed : @hashset.T[String] = @hashset.new()
@@ -207,7 +207,7 @@ fn[T, U] diff_event(
   old_event : Map[RespoEventType, U],
   coord : @immut/array.T[RespoCoord],
   dom_path : @immut/array.T[UInt],
-  changes : Ref[Array[DomChange[T]]]
+  changes : Ref[Array[DomChange[T]]],
 ) -> Unit {
   let new_keys = @hashset.from_array(
     new_event.to_array().map(fn(pair) { pair.0 }),
@@ -233,7 +233,7 @@ fn[T] diff_children(
   old_children : Array[(RespoIndexKey, RespoNode[T])],
   coord : @immut/array.T[RespoCoord],
   dom_path : @immut/array.T[UInt],
-  changes : Ref[Array[DomChange[T]]]
+  changes : Ref[Array[DomChange[T]]],
 ) -> Unit raise RespoCommonError {
   let mut cursor : UInt = 0
   let operations : Ref[Array[ChildDomOp[T]]] = @ref.new([])
@@ -364,7 +364,7 @@ pub fn[T] collect_effects_outside_in_as(
   coord : @immut/array.T[RespoCoord],
   dom_path : @immut/array.T[UInt],
   effect_type : RespoEffectType,
-  changes : Ref[Array[DomChange[T]]]
+  changes : Ref[Array[DomChange[T]]],
 ) -> Unit raise RespoCommonError {
   match tree {
     Component(left) => {
@@ -401,7 +401,7 @@ pub fn[T] collect_effects_inside_out_as(
   coord : @immut/array.T[RespoCoord],
   dom_path : @immut/array.T[UInt],
   effect_type : RespoEffectType,
-  changes : Ref[Array[DomChange[T]]]
+  changes : Ref[Array[DomChange[T]]],
 ) -> Unit raise RespoCommonError {
   match tree {
     Component(left) => {
@@ -440,7 +440,7 @@ fn[T] nested_effects_outside_in_as(
   coord : @immut/array.T[RespoCoord],
   dom_path : @immut/array.T[UInt],
   effect_type : RespoEffectType,
-  operations : Ref[Array[ChildDomOp[T]]]
+  operations : Ref[Array[ChildDomOp[T]]],
 ) -> Unit raise RespoCommonError {
   match tree {
     Component(left) => {
@@ -481,7 +481,7 @@ fn[T] nested_effects_inside_out_as(
   coord : @immut/array.T[RespoCoord],
   dom_path : @immut/array.T[UInt],
   effect_type : RespoEffectType,
-  operations : Ref[Array[ChildDomOp[T]]]
+  operations : Ref[Array[ChildDomOp[T]]],
 ) -> Unit raise RespoCommonError {
   match tree {
     Component(left) => {

--- a/src/lib/node/effect.mbt
+++ b/src/lib/node/effect.mbt
@@ -67,7 +67,7 @@ impl RespoEffect with before_unmount(_self, _node) -> Unit {
 ///|
 pub impl Eq for RespoEffectBox with op_equal(
   self : RespoEffectBox,
-  b : RespoEffectBox
+  b : RespoEffectBox,
 ) -> Bool {
   self.args == b.args
 }

--- a/src/lib/node/element.mbt
+++ b/src/lib/node/element.mbt
@@ -1,5 +1,5 @@
 ///|
-pub(all) type RespoIndexKey String derive(Eq)
+pub(all) struct RespoIndexKey(String) derive(Eq)
 
 ///|
 pub fn RespoIndexKey::to_cirru(self : RespoIndexKey) -> Cirru {
@@ -36,7 +36,7 @@ pub fn[T] RespoElement::to_node(self : RespoElement[T]) -> RespoNode[T] {
 ///|
 pub impl[T] Eq for RespoElement[T] with op_equal(
   self : RespoElement[T],
-  other : RespoElement[T]
+  other : RespoElement[T],
 ) -> Bool {
   if self.name != other.name {
     return false
@@ -74,7 +74,7 @@ pub impl[T] Show for RespoElement[T] with output(self, logger) {
 pub fn[T] set_attribute(
   self : RespoElement[T],
   key : String,
-  value : String
+  value : String,
 ) -> Unit {
   self.attrs.set(key, value)
 }
@@ -107,7 +107,7 @@ pub fn respo_attrs(
   width? : String,
   height? : String,
   inner_text? : String,
-  innerHTML? : String
+  innerHTML? : String,
 ) -> Map[String, String] {
   let result = {}
   match id {

--- a/src/lib/node/node.mbt
+++ b/src/lib/node/node.mbt
@@ -7,7 +7,7 @@ pub(all) enum RespoNode[T] {
 ///|
 pub impl[T] Eq for RespoNode[T] with op_equal(
   self : RespoNode[T],
-  other : RespoNode[T]
+  other : RespoNode[T],
 ) -> Bool {
   match (self, other) {
     (Component(left), Component(right)) => left == right
@@ -47,7 +47,7 @@ pub impl Show for RespoCommonError with output(self, logger) {
 ///|
 pub fn[T] load_coord_target_tree(
   tree : RespoNode[T],
-  coord : ArrayView[RespoCoord]
+  coord : ArrayView[RespoCoord],
 ) -> RespoNode[T] raise RespoCommonError {
   // @dom_ffi.log("looking for " + coord.to_string() + tree.to_string())
   if coord.length() == 0 {
@@ -97,7 +97,7 @@ pub fn[T] load_coord_target_tree(
 pub fn[T] build_dom_tree(
   tree : RespoNode[T],
   coord : @immut/array.T[RespoCoord],
-  handle_event : (RespoEventMark) -> Unit raise RespoCommonError
+  handle_event : (RespoEventMark) -> Unit raise RespoCommonError,
 ) -> @dom_ffi.Node raise RespoCommonError {
   let window = @dom_ffi.window()
   let document = window.document()
@@ -166,7 +166,7 @@ pub fn[T] build_dom_tree(
 }
 
 ///|
-pub(all) type DispatchFn[T] (T) -> Unit raise RespoCommonError
+pub(all) struct DispatchFn[T]((T) -> Unit raise RespoCommonError)
 
 ///|
 pub impl[T] Show for DispatchFn[T] with output(self, logger) {
@@ -187,7 +187,7 @@ pub(open) trait RespoAction {
 ///|
 pub fn[T] DispatchFn::run(
   self : DispatchFn[T],
-  op : T
+  op : T,
 ) -> Unit raise RespoCommonError {
   let f = self.inner()
   f(op)
@@ -208,7 +208,7 @@ pub fn[T] RespoCursor::new(cursor : Array[String]) -> RespoCursor[T] {
 pub fn[T : RespoAction, S : ToJson] DispatchFn::set_state(
   self : DispatchFn[T],
   cursor : RespoCursor[S],
-  state : S
+  state : S,
 ) -> Unit raise RespoCommonError {
   let op = T::build_states_action(cursor.cursor, Some(state))
   self.run(op)
@@ -219,7 +219,7 @@ pub fn[T : RespoAction, S : ToJson] DispatchFn::set_state(
 pub fn[T : RespoAction] DispatchFn::run_state(
   self : DispatchFn[T],
   cursor : Array[String],
-  state : &ToJson
+  state : &ToJson,
 ) -> Unit raise RespoCommonError {
   let op = T::build_states_action(cursor, Some(state))
   self.run(op)
@@ -236,7 +236,7 @@ pub fn[T : RespoAction] DispatchFn::run_state(
 ///| dispatch an action to update states, to empty the state, pass None
 pub fn[T : RespoAction, S] DispatchFn::empty_state(
   self : DispatchFn[T],
-  cursor : RespoCursor[S]
+  cursor : RespoCursor[S],
 ) -> Unit raise RespoCommonError {
   let op = T::build_states_action(cursor.cursor, None)
   self.run(op)
@@ -246,7 +246,7 @@ pub fn[T : RespoAction, S] DispatchFn::empty_state(
 #deprecated("use `empty_state` instead")
 pub fn[T : RespoAction] DispatchFn::run_empty_state(
   self : DispatchFn[T],
-  cursor : Array[String]
+  cursor : Array[String],
 ) -> Unit raise RespoCommonError {
   let op = T::build_states_action(cursor, None)
   self.run(op)
@@ -254,7 +254,7 @@ pub fn[T : RespoAction] DispatchFn::run_empty_state(
 
 ///|
 pub fn[T] DispatchFn::new(
-  f : (T) -> Unit raise RespoCommonError
+  f : (T) -> Unit raise RespoCommonError,
 ) -> DispatchFn[T] {
   f
 }

--- a/src/lib/node/patch.mbt
+++ b/src/lib/node/patch.mbt
@@ -4,7 +4,7 @@ pub fn[T] patch_tree(
   old_tree : RespoNode[T],
   mount_target : @dom_ffi.Node,
   changes : Array[DomChange[T]],
-  handle_event : (RespoEventMark) -> Unit raise RespoCommonError
+  handle_event : (RespoEventMark) -> Unit raise RespoCommonError,
 ) -> Unit raise RespoCommonError {
   // let el = mount_target.dyn_ref::<Element>().expect("to element");
 
@@ -260,7 +260,7 @@ pub fn[T] patch_tree(
 ///|
 fn find_coord_dom_target(
   mount_target : @dom_ffi.Node,
-  coord : Array[UInt]
+  coord : Array[UInt],
 ) -> @dom_ffi.Node raise RespoCommonError {
   let mut target = mount_target
   for idx in coord {
@@ -280,7 +280,7 @@ pub fn attach_event(
   element : @dom_ffi.Element,
   key : RespoEventType,
   coord : @immut/array.T[RespoCoord],
-  handle_event : (RespoEventMark) -> Unit raise RespoCommonError
+  handle_event : (RespoEventMark) -> Unit raise RespoCommonError,
 ) -> Unit raise RespoCommonError {
   // @dom_ffi.log("attach event: " + key.to_string())
   match key {

--- a/src/lib/node/util.mbt
+++ b/src/lib/node/util.mbt
@@ -1,4 +1,5 @@
 // compare hashset
+
 ///|
 fn[T : Eq + Hash] hashset_eq(xs : @hashset.T[T], ys : @hashset.T[T]) -> Bool {
   if xs.size() != ys.size() {

--- a/src/lib/renderer.mbt
+++ b/src/lib/renderer.mbt
@@ -28,13 +28,13 @@ pub fn[T, U] render_node(
   store : Ref[U],
   renderer : () -> @node.RespoNode[T] raise @node.RespoCommonError,
   dispatch_action : (T) -> Unit raise @node.RespoCommonError,
-  _interval : Float?
+  _interval : Float?,
 ) -> Unit raise @node.RespoCommonError {
   let prev_store = @ref.new(store.val)
   let tree0 : @node.RespoNode[T] = renderer()
   let prev_tree = @ref.new(tree0)
   let handle_event = fn(
-    mark : @node.RespoEventMark
+    mark : @node.RespoEventMark,
   ) -> Unit raise @node.RespoCommonError {
     // @dom_ffi.warn_log(
     //   "start rendering: " + mark.name.to_string() + " " + mark.coord.to_string(),
@@ -99,7 +99,7 @@ pub fn[T, U] render_node(
 fn[T] request_for_target_handler(
   tree : @node.RespoNode[T],
   event_name : @node.RespoEventType,
-  coord : @immut/array.T[@node.RespoCoord]
+  coord : @immut/array.T[@node.RespoCoord],
 ) -> ((@node.RespoEvent, @node.DispatchFn[T]) -> Unit raise @node.RespoCommonError) raise @node.RespoCommonError {
   let target_node = @node.load_coord_target_tree(tree, coord.to_array())
   match target_node {

--- a/src/lib/states-tree.mbt
+++ b/src/lib/states-tree.mbt
@@ -150,7 +150,7 @@ pub fn[T : Default + @json.FromJson] cast_branch(self : RespoStatesTree) -> T {
 /// let (state, cursor): (LocalState, _) = states.local_pair();
 /// ```
 pub fn[T : Default + @json.FromJson] local_pair(
-  self : RespoStatesTree
+  self : RespoStatesTree,
 ) -> (T, @node.RespoCursor[T]) {
   let data = self.cast_branch()
   let cursor = self.path()

--- a/src/main/counter.mbt
+++ b/src/main/counter.mbt
@@ -22,7 +22,7 @@ struct MainState {
 ///|
 fn comp_counter(
   states : RespoStatesTree,
-  global_counted : Int
+  global_counted : Int,
 ) -> RespoNode[ActionOp] {
   let ((state : MainState), cursor) = states.local_pair()
   let counted = state.counted

--- a/src/main/panel.mbt
+++ b/src/main/panel.mbt
@@ -32,7 +32,7 @@ fn comp_panel(states : RespoStatesTree) -> RespoNode[ActionOp] {
   let ((state : PanelState), cursor) = states.local_pair()
   let on_input = fn(
     e : RespoEvent,
-    dispatch : DispatchFn[ActionOp]
+    dispatch : DispatchFn[ActionOp],
   ) -> Unit raise RespoCommonError {
     @dom_ffi.log("input event: " + e.to_string())
     if e is Input(value~, ..) {
@@ -41,7 +41,7 @@ fn comp_panel(states : RespoStatesTree) -> RespoNode[ActionOp] {
   }
   let on_submit = fn(
     e : RespoEvent,
-    dispatch : DispatchFn[ActionOp]
+    dispatch : DispatchFn[ActionOp],
   ) -> Unit raise RespoCommonError {
     @dom_ffi.log("add button: \{e}")
     dispatch.run(AddTask(@dom_ffi.random_id(), state.content))

--- a/src/main/plugins.mbt
+++ b/src/main/plugins.mbt
@@ -1,6 +1,6 @@
 ///|
 fn comp_plugins_demo(
-  states : RespoStatesTree
+  states : RespoStatesTree,
 ) -> RespoNode[ActionOp] raise RespoCommonError {
   // respo::util::log!("re-render");
 
@@ -13,7 +13,7 @@ fn comp_plugins_demo(
   )
   let on_alert = fn(
     e : RespoEvent,
-    dispatch : DispatchFn[ActionOp]
+    dispatch : DispatchFn[ActionOp],
   ) -> Unit raise RespoCommonError {
     @dom_ffi.log("click " + e.to_string())
 
@@ -27,7 +27,7 @@ fn comp_plugins_demo(
   )
   let on_confirm = fn(
     e : RespoEvent,
-    dispatch : DispatchFn[ActionOp]
+    dispatch : DispatchFn[ActionOp],
   ) -> Unit raise RespoCommonError {
     @dom_ffi.log("click " + e.to_string())
     confirm_plugin.show(dispatch, () => @dom_ffi.log("do something on confirm"))
@@ -56,7 +56,7 @@ fn comp_plugins_demo(
   )
   let on_prompt = fn(
     e : RespoEvent,
-    dispatch : DispatchFn[ActionOp]
+    dispatch : DispatchFn[ActionOp],
   ) -> Unit raise RespoCommonError {
     @dom_ffi.log("click " + e.to_string())
     prompt_plugin.show(dispatch, fn(content) {
@@ -89,7 +89,7 @@ fn comp_plugins_demo(
   })
   let on_modal = fn(
     e : RespoEvent,
-    dispatch : DispatchFn[ActionOp]
+    dispatch : DispatchFn[ActionOp],
   ) -> Unit raise RespoCommonError {
     @dom_ffi.log("click " + e.to_string())
     modal_plugin.show(dispatch)
@@ -103,7 +103,7 @@ fn comp_plugins_demo(
     render: @dialog.DrawerRenderer::new(fn(close_drawer) {
       let handler = fn(
         _e : _,
-        dispatch : DispatchFn[ActionOp]
+        dispatch : DispatchFn[ActionOp],
       ) -> Unit raise RespoCommonError {
         @dom_ffi.log("on modal handle")
         close_drawer(dispatch)
@@ -123,7 +123,7 @@ fn comp_plugins_demo(
   })
   let on_drawer = fn(
     e : RespoEvent,
-    dispatch : DispatchFn[ActionOp]
+    dispatch : DispatchFn[ActionOp],
   ) -> Unit raise RespoCommonError {
     @dom_ffi.log("click " + e.to_string())
     drawer_plugin.show(dispatch)

--- a/src/main/task.mbt
+++ b/src/main/task.mbt
@@ -20,14 +20,14 @@ fn comp_task(states : RespoStatesTree, task : Task) -> RespoNode[ActionOp] {
   let ((state : TaskState), cursor) = states.local_pair()
   let on_toggle = fn(
     _e : RespoEvent,
-    dispatch : DispatchFn[ActionOp]
+    dispatch : DispatchFn[ActionOp],
   ) -> Unit raise RespoCommonError {
     @dom_ffi.log("TOGGLE TASK \{task_id}")
     dispatch.run(ToggleTask(task_id))
   }
   let on_input = fn(
     e : RespoEvent,
-    dispatch : DispatchFn[ActionOp]
+    dispatch : DispatchFn[ActionOp],
   ) -> Unit raise RespoCommonError {
     if e is Input(value~, ..) {
       dispatch.set_state(cursor, { draft: value })
@@ -36,14 +36,14 @@ fn comp_task(states : RespoStatesTree, task : Task) -> RespoNode[ActionOp] {
   let tid = task_id
   let on_remove = fn(
     e : RespoEvent,
-    dispatch : DispatchFn[ActionOp]
+    dispatch : DispatchFn[ActionOp],
   ) -> Unit raise RespoCommonError {
     @dom_ffi.log("remove button {}" + e.to_string())
     dispatch.run(RemoveTask(tid))
   }
   let on_update = fn(
     _e : RespoEvent,
-    dispatch : DispatchFn[ActionOp]
+    dispatch : DispatchFn[ActionOp],
   ) -> Unit raise RespoCommonError {
     dispatch.run(UpdateTask(tid, state.draft))
     // dispatch.run_empty_state(&cursor)?;

--- a/src/main/todolist.mbt
+++ b/src/main/todolist.mbt
@@ -9,7 +9,7 @@ struct TodolistState {
 ///|
 fn comp_todolist(
   states : RespoStatesTree,
-  tasks : Array[Task]
+  tasks : Array[Task],
 ) -> RespoNode[ActionOp] {
   let ((state : TodolistState), cursor) = states.local_pair()
   let children : Array[(RespoIndexKey, RespoNode[ActionOp])] = []
@@ -26,7 +26,7 @@ fn comp_todolist(
 
   let on_hide = fn(
     e : RespoEvent,
-    dispatch : DispatchFn[ActionOp]
+    dispatch : DispatchFn[ActionOp],
   ) -> Unit raise RespoCommonError {
     @dom_ffi.log("click: " + e.to_string())
     dispatch.set_state(cursor, { hide_done: not(state.hide_done) })


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Fix deprecated newtype syntax: change `type CssBorder (Float, CssBorderStyle, CssColor)` to `struct CssBorder((Float, CssBorderStyle, CssColor))`
- Apply automatic code formatting to ensure consistent style
- All warnings now resolved when compiling with `--target js` (the project's primary target)

This ensures the project compiles cleanly with the MoonBit compiler and follows current syntax standards.