### PR TITLE
fix: resolve all deprecation warnings

### DIFF
--- a/src/dialog/dialogs.mbt
+++ b/src/dialog/dialogs.mbt
@@ -97,7 +97,7 @@ priv struct EffectDrawerFade {
 
 ///|
 impl @node.RespoEffect for EffectDrawerFade with before_update(self, el) {
-  if not(self.show) {
+  if !self.show {
     if el.first_child() is Some(target) {
       let cloned = target.clone_node(deep=true)
       let document = el.owner_document()

--- a/src/global_event.mbt
+++ b/src/global_event.mbt
@@ -3,24 +3,24 @@
 /// Returns an array of handler functions with their coordinates
 pub fn[T, G] collect_global_handlers(
   tree : @node.RespoNode[T, G],
-  coord : @immut/array.T[@node.RespoCoord],
+  coord : @immut/vector.Vector[@node.RespoCoord],
 ) -> Array[
   (
     (G, @node.DispatchFn[T]) -> Unit raise @node.RespoCommonError,
-    @immut/array.T[@node.RespoCoord],
+    @immut/vector.Vector[@node.RespoCoord],
   ),
 ] {
   let handlers : Array[
     (
       (G, @node.DispatchFn[T]) -> Unit raise @node.RespoCommonError,
-      @immut/array.T[@node.RespoCoord],
+      @immut/vector.Vector[@node.RespoCoord],
     ),
   ] = []
 
   // Helper function to recursively traverse the tree
   fn collect_from_node(
     node : @node.RespoNode[T, G],
-    current_coord : @immut/array.T[@node.RespoCoord],
+    current_coord : @immut/vector.Vector[@node.RespoCoord],
   ) -> Unit {
     match node {
       @node.Component(component) => {
@@ -52,7 +52,7 @@ pub fn[T, G] dispatch_global_event(
   tree : @node.RespoNode[T, G],
   dispatch : @node.DispatchFn[T],
 ) -> Unit raise @node.RespoCommonError {
-  let handlers = collect_global_handlers(tree, @immut/array.new())
+  let handlers = collect_global_handlers(tree, @immut/vector.new())
 
   // Call each handler with the event
   for _i, handler_info in handlers {

--- a/src/main/moon.pkg
+++ b/src/main/moon.pkg
@@ -5,7 +5,7 @@ import {
   "tiye/dom-ffi" @dom_ffi,
   "tiye/respo_css" @css,
   "moonbitlang/core/json" @json,
-  "moonbitlang/core/immut/array" @immut/array,
+  "moonbitlang/core/immut/vector" @immut/vector,
 }
 
 options(

--- a/src/main/store.mbt
+++ b/src/main/store.mbt
@@ -3,19 +3,27 @@
 enum GlobalEvent {
   Placeholder // Default placeholder
   KeyPress(String) // Keyboard key press with key name
-} derive(Default, Show, Eq)
+} derive(Default, Debug, Eq)
+
+///|
+impl Show for GlobalEvent with output(self, logger) {
+  match self {
+    Placeholder => logger.write_string("Placeholder")
+    KeyPress(key) => logger.write_string("KeyPress(\{key})")
+  }
+}
 
 ///|
 /// Store is immutable, use record update syntax to create new store
 struct Store {
   counted : Int
-  tasks : @immut/array.T[Task]
+  tasks : @immut/vector.Vector[Task]
   states : RespoStatesTree
 } derive(Eq)
 
 ///|
 impl Default for Store with default() -> Store {
-  { counted: 0, tasks: @immut/array.new(), states: RespoStatesTree::default() }
+  { counted: 0, tasks: @immut/vector.new(), states: RespoStatesTree::default() }
 }
 
 ///|
@@ -45,7 +53,7 @@ impl @json.FromJson for Store with from_json(json, path) {
     Some(v) => @json.from_json(v, path~)
     None => raise @json.JsonDecodeError((path, "missing states"))
   }
-  { counted, tasks: @immut/array.from_array(tasks_arr), states }
+  { counted, tasks: @immut/vector.from_array(tasks_arr), states }
 }
 
 ///|
@@ -136,7 +144,7 @@ fn Store::update(self : Store, op : ActionOp) -> Store {
     }
     RemoveTask(id) => {
       // Use iter + filter + from_iter for immutable filtering
-      let new_tasks = @immut/array.from_iter(
+      let new_tasks = @immut/vector.from_iter(
         self.tasks.iter().filter(fn(task) { task.id != id }),
       )
       { ..self, tasks: new_tasks }
@@ -154,7 +162,7 @@ fn Store::update(self : Store, op : ActionOp) -> Store {
     ToggleTask(id) => {
       let new_tasks = self.tasks.map(fn(task) {
         if task.id == id {
-          { ..task, done: not(task.done) }
+          { ..task, done: !task.done }
         } else {
           task
         }

--- a/src/main/todolist.mbt
+++ b/src/main/todolist.mbt
@@ -9,7 +9,7 @@ struct TodolistState {
 ///|
 fn comp_todolist(
   states : RespoStatesTree,
-  tasks : @immut/array.T[Task],
+  tasks : @immut/vector.Vector[Task],
 ) -> RespoNode[ActionOp, GlobalEvent] {
   let ((state : TodolistState), cursor) = states.local_pair()
   let children : Array[(RespoIndexKey, RespoNode[ActionOp, GlobalEvent])] = []
@@ -29,7 +29,7 @@ fn comp_todolist(
     dispatch : DispatchFn[ActionOp],
   ) -> Unit raise RespoCommonError {
     @dom_ffi.log("click: " + e.to_string())
-    dispatch.set_state(cursor, { hide_done: not(state.hide_done) })
+    dispatch.set_state(cursor, { hide_done: !state.hide_done })
   }
   div([
     div([

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -5,6 +5,6 @@ import {
   "moonbitlang/core/json" @json,
   "moonbitlang/core/hashmap" @hashmap,
   "moonbitlang/core/immut/hashmap" @immut/hashmap,
-  "moonbitlang/core/immut/array" @immut/array,
+  "moonbitlang/core/immut/vector" @immut/vector,
   "moonbitlang/core/ref" @ref,
 }

--- a/src/node/alias.mbt
+++ b/src/node/alias.mbt
@@ -76,12 +76,12 @@ fn combile_classes(class_name : String?, class_list : Array[String]) -> String? 
   if class_name is Some(class_name) {
     class_content += " " + class_name
   }
-  if not(class_list.is_empty()) {
+  if !class_list.is_empty() {
     for class_name in class_list {
       class_content += " " + class_name
     }
   }
-  class_content = class_content.trim(char_set=" ").to_string()
+  class_content = class_content.trim(char_set=" ").to_owned()
   if class_content.is_empty() {
     None
   } else {

--- a/src/node/component.mbt
+++ b/src/node/component.mbt
@@ -15,10 +15,10 @@ pub impl[T, G] Eq for RespoComponent[T, G] with equal(
   if self.name != other.name {
     return false
   }
-  if not(self.effects == other.effects) {
+  if !(self.effects == other.effects) {
     return false
   }
-  if not(self.tree == other.tree) {
+  if !(self.tree == other.tree) {
     return false
   }
   // listeners 不参与比较，因为它们是函数

--- a/src/node/css.mbt
+++ b/src/node/css.mbt
@@ -68,7 +68,7 @@ fn gen_class_name_from_loc_fallback(loc : SourceLoc) -> String {
     .replace_all(old=".mbt", new="_")
     .replace_all(old=":", new="_")
     .replace_all(old=".", new="_")
-    .to_string()
+    .to_owned()
   }
 
   if parts.length() >= 2 {
@@ -77,7 +77,7 @@ fn gen_class_name_from_loc_fallback(loc : SourceLoc) -> String {
     let ns_clean = ns_part
       .replace_all(old="/", new="_")
       .replace_all(old=".", new="_")
-    (ns_clean + "_" + clean_file_part(file_part)).to_string()
+    (ns_clean + "_" + clean_file_part(file_part)).to_owned()
   } else {
     // fallback for old format without namespace
     clean_file_part(loc_str[:])

--- a/src/node/diff.mbt
+++ b/src/node/diff.mbt
@@ -3,8 +3,8 @@
 pub fn[T, G] diff_tree(
   new_tree : RespoNode[T, G],
   old_tree : RespoNode[T, G],
-  coord : @immut/array.T[RespoCoord],
-  dom_path : @immut/array.T[UInt],
+  coord : @immut/vector.Vector[RespoCoord],
+  dom_path : @immut/vector.Vector[UInt],
   changes : Ref[Array[DomChange[T, G]]],
 ) -> Unit raise RespoCommonError {
   if physical_equal(new_tree, old_tree) {
@@ -129,8 +129,8 @@ pub fn[T, G] diff_tree(
 fn[T, G] diff_attrs(
   new_attrs : Map[String, String],
   old_attrs : Map[String, String],
-  coord : @immut/array.T[RespoCoord],
-  dom_path : @immut/array.T[UInt],
+  coord : @immut/vector.Vector[RespoCoord],
+  dom_path : @immut/vector.Vector[UInt],
   changes : Ref[Array[DomChange[T, G]]],
   reset_inner : Ref[Bool],
 ) -> Unit {
@@ -154,14 +154,14 @@ fn[T, G] diff_attrs(
   }
   for pair in old_attrs.iter() {
     let (key, _) = pair
-    if not(new_attrs.contains(key)) {
+    if !new_attrs.contains(key) {
       removed.add(key)
       if inner_changed(key) {
         reset_inner.val = true
       }
     }
   }
-  if not(added.is_empty()) || not(removed.is_empty()) {
+  if !added.is_empty() || !removed.is_empty() {
     changes.val.push(ModifyAttrs(coord~, dom_path~, set=added, unset=removed))
   }
 }
@@ -176,8 +176,8 @@ fn inner_changed(key : String) -> Bool {
 fn[T, G] diff_style(
   new_style : Map[String, String],
   old_style : Map[String, String],
-  coord : @immut/array.T[RespoCoord],
-  dom_path : @immut/array.T[UInt],
+  coord : @immut/vector.Vector[RespoCoord],
+  dom_path : @immut/vector.Vector[UInt],
   changes : Ref[Array[DomChange[T, G]]],
 ) -> Unit {
   let added : Map[String, String] = {}
@@ -194,11 +194,11 @@ fn[T, G] diff_style(
   }
   for pair in old_style {
     let (key, _) = pair
-    if not(new_style.contains(key)) {
+    if !new_style.contains(key) {
       removed.add(key)
     }
   }
-  if not(added.is_empty()) || not(removed.is_empty()) {
+  if !added.is_empty() || !removed.is_empty() {
     changes.val.push(ModifyStyle(coord~, dom_path~, set=added, unset=removed))
   }
 }
@@ -207,8 +207,8 @@ fn[T, G] diff_style(
 fn[T, U, G] diff_event(
   new_event : Map[RespoEventType, U],
   old_event : Map[RespoEventType, U],
-  coord : @immut/array.T[RespoCoord],
-  dom_path : @immut/array.T[UInt],
+  coord : @immut/vector.Vector[RespoCoord],
+  dom_path : @immut/vector.Vector[UInt],
   changes : Ref[Array[DomChange[T, G]]],
 ) -> Unit {
   let new_keys = @hashset.from_array(
@@ -217,7 +217,7 @@ fn[T, U, G] diff_event(
   let old_keys = @hashset.from_array(
     old_event.to_array().map(fn(pair) { pair.0 }),
   )
-  if not(hashset_eq(new_keys, old_keys)) {
+  if !hashset_eq(new_keys, old_keys) {
     changes.val.push(
       ModifyEvent(
         coord~,
@@ -233,8 +233,8 @@ fn[T, U, G] diff_event(
 fn[T, G] diff_children(
   new_children : Array[(RespoIndexKey, RespoNode[T, G])],
   old_children : Array[(RespoIndexKey, RespoNode[T, G])],
-  coord : @immut/array.T[RespoCoord],
-  dom_path : @immut/array.T[UInt],
+  coord : @immut/vector.Vector[RespoCoord],
+  dom_path : @immut/vector.Vector[UInt],
   changes : Ref[Array[DomChange[T, G]]],
 ) -> Unit raise RespoCommonError {
   let mut cursor : UInt = 0
@@ -244,7 +244,7 @@ fn[T, G] diff_children(
   for ;; {
     if new_tracking_pointer >= new_children.length() {
       if old_tracking_pointer >= old_children.length() {
-        if not(operations.val.is_empty()) {
+        if !operations.val.is_empty() {
           changes.val.push(
             ModifyChildren(coord~, dom_path~, operations=operations.val),
           )
@@ -252,8 +252,8 @@ fn[T, G] diff_children(
         return
       } else {
         let old_entry = old_children[old_tracking_pointer]
-        let child_coord = @immut/array.from_array([Key(old_entry.0)])
-        let child_dom_path = @immut/array.from_array([cursor])
+        let child_coord = @immut/vector.from_array([Key(old_entry.0)])
+        let child_dom_path = @immut/vector.from_array([cursor])
         nested_effects_inside_out_as(
           old_entry.1,
           child_coord,
@@ -267,8 +267,8 @@ fn[T, G] diff_children(
     } else if old_tracking_pointer >= old_children.length() {
       let (new_key, new_child) = new_children[new_tracking_pointer]
       operations.val.push(Append(new_key, new_child))
-      let child_coord = @immut/array.from_array([Key(new_key)])
-      let child_dom_path = @immut/array.from_array([cursor])
+      let child_coord = @immut/vector.from_array([Key(new_key)])
+      let child_dom_path = @immut/vector.from_array([cursor])
       nested_effects_outside_in_as(
         new_child,
         child_coord,
@@ -292,8 +292,8 @@ fn[T, G] diff_children(
         Some(new_entry.0) == old_children.get(old_tracking_pointer + 2).map(fst) ||
         Some(new_entry.0) == old_children.get(old_tracking_pointer + 3).map(fst) {
         // look ahead for 3 entries, if still not found, regards this as a remove
-        let child_coord = @immut/array.from_array([Key(old_entry.0)])
-        let child_dom_path = @immut/array.from_array([cursor])
+        let child_coord = @immut/vector.from_array([Key(old_entry.0)])
+        let child_dom_path = @immut/vector.from_array([cursor])
         nested_effects_inside_out_as(
           old_entry.1,
           child_coord,
@@ -312,8 +312,8 @@ fn[T, G] diff_children(
         } else {
           operations.val.push(InsertAfter(cursor - 1, new_entry.0, new_entry.1))
         }
-        let child_coord = @immut/array.from_array([Key(new_entry.0)])
-        let child_dom_path = @immut/array.from_array([cursor])
+        let child_coord = @immut/vector.from_array([Key(new_entry.0)])
+        let child_dom_path = @immut/vector.from_array([cursor])
         nested_effects_outside_in_as(
           new_entry.1,
           child_coord,
@@ -324,10 +324,10 @@ fn[T, G] diff_children(
         cursor += 1
         new_tracking_pointer += 1
       } else {
-        let child_coord : @immut/array.T[RespoCoord] = @immut/array.from_array([
+        let child_coord : @immut/vector.Vector[RespoCoord] = @immut/vector.from_array([
           Key(old_entry.0),
         ])
-        let child_dom_path = @immut/array.from_array([cursor])
+        let child_dom_path = @immut/vector.from_array([cursor])
         nested_effects_inside_out_as(
           old_entry.1,
           child_coord,
@@ -341,8 +341,8 @@ fn[T, G] diff_children(
         } else {
           operations.val.push(InsertAfter(cursor - 1, new_entry.0, new_entry.1))
         }
-        let child_coord = @immut/array.from_array([Key(new_entry.0)])
-        let child_dom_path = @immut/array.from_array([cursor])
+        let child_coord = @immut/vector.from_array([Key(new_entry.0)])
+        let child_dom_path = @immut/vector.from_array([cursor])
         nested_effects_outside_in_as(
           new_entry.1,
           child_coord,
@@ -363,15 +363,15 @@ fn[T, G] diff_children(
 ///|
 pub fn[T, G] collect_effects_outside_in_as(
   tree : RespoNode[T, G],
-  coord : @immut/array.T[RespoCoord],
-  dom_path : @immut/array.T[UInt],
+  coord : @immut/vector.Vector[RespoCoord],
+  dom_path : @immut/vector.Vector[UInt],
   effect_type : RespoEffectType,
   changes : Ref[Array[DomChange[T, G]]],
 ) -> Unit raise RespoCommonError {
   match tree {
     Component(left) => {
       let { name, effects, tree, .. } = left
-      if not(effects.is_empty()) {
+      if !effects.is_empty() {
         changes.val.push(
           Effect(coord~, dom_path~, effect_type~, skip_indexes=@hashset.new()),
         )
@@ -400,8 +400,8 @@ pub fn[T, G] collect_effects_outside_in_as(
 ///|
 pub fn[T, G] collect_effects_inside_out_as(
   tree : RespoNode[T, G],
-  coord : @immut/array.T[RespoCoord],
-  dom_path : @immut/array.T[UInt],
+  coord : @immut/vector.Vector[RespoCoord],
+  dom_path : @immut/vector.Vector[UInt],
   effect_type : RespoEffectType,
   changes : Ref[Array[DomChange[T, G]]],
 ) -> Unit raise RespoCommonError {
@@ -412,7 +412,7 @@ pub fn[T, G] collect_effects_inside_out_as(
       collect_effects_inside_out_as(
         tree, next_coord, dom_path, effect_type, changes,
       )
-      if not(effects.is_empty()) {
+      if !effects.is_empty() {
         changes.val.push(
           Effect(coord~, dom_path~, effect_type~, skip_indexes=@hashset.new()),
         )
@@ -439,15 +439,15 @@ pub fn[T, G] collect_effects_inside_out_as(
 ///|
 fn[T, G] nested_effects_outside_in_as(
   tree : RespoNode[T, G],
-  coord : @immut/array.T[RespoCoord],
-  dom_path : @immut/array.T[UInt],
+  coord : @immut/vector.Vector[RespoCoord],
+  dom_path : @immut/vector.Vector[UInt],
   effect_type : RespoEffectType,
   operations : Ref[Array[ChildDomOp[T, G]]],
 ) -> Unit raise RespoCommonError {
   match tree {
     Component(left) => {
       let { name, effects, tree, .. } = left
-      if not(effects.is_empty()) {
+      if !effects.is_empty() {
         operations.val.push(
           NestedEffect(
             nested_coord=coord,
@@ -480,8 +480,8 @@ fn[T, G] nested_effects_outside_in_as(
 ///|
 fn[T, G] nested_effects_inside_out_as(
   tree : RespoNode[T, G],
-  coord : @immut/array.T[RespoCoord],
-  dom_path : @immut/array.T[UInt],
+  coord : @immut/vector.Vector[RespoCoord],
+  dom_path : @immut/vector.Vector[UInt],
   effect_type : RespoEffectType,
   operations : Ref[Array[ChildDomOp[T, G]]],
 ) -> Unit raise RespoCommonError {
@@ -492,7 +492,7 @@ fn[T, G] nested_effects_inside_out_as(
       nested_effects_inside_out_as(
         tree, next_coord, dom_path, effect_type, operations,
       )
-      if not(effects.is_empty()) {
+      if !effects.is_empty() {
         operations.val.push(
           NestedEffect(
             nested_coord=coord,

--- a/src/node/dom-change.mbt
+++ b/src/node/dom-change.mbt
@@ -20,36 +20,36 @@ pub impl Show for RespoCoord with output(self, logger) -> Unit {
 /// Diff/patch for virtual DOM, note that children are not included in this type
 enum DomChange[T, G] {
   ReplaceElement(
-    coord~ : @immut/array.T[RespoCoord],
-    dom_path~ : @immut/array.T[UInt],
+    coord~ : @immut/vector.Vector[RespoCoord],
+    dom_path~ : @immut/vector.Vector[UInt],
     node~ : RespoNode[T, G]
   )
   ModifyChildren(
-    coord~ : @immut/array.T[RespoCoord],
-    dom_path~ : @immut/array.T[UInt],
+    coord~ : @immut/vector.Vector[RespoCoord],
+    dom_path~ : @immut/vector.Vector[UInt],
     operations~ : Array[ChildDomOp[T, G]]
   )
   ModifyAttrs(
-    coord~ : @immut/array.T[RespoCoord],
-    dom_path~ : @immut/array.T[UInt],
+    coord~ : @immut/vector.Vector[RespoCoord],
+    dom_path~ : @immut/vector.Vector[UInt],
     set~ : Map[String, String],
     unset~ : @hashset.HashSet[String]
   )
   ModifyStyle(
-    coord~ : @immut/array.T[RespoCoord],
-    dom_path~ : @immut/array.T[UInt],
+    coord~ : @immut/vector.Vector[RespoCoord],
+    dom_path~ : @immut/vector.Vector[UInt],
     set~ : Map[String, String],
     unset~ : @hashset.HashSet[String]
   )
   ModifyEvent(
-    coord~ : @immut/array.T[RespoCoord],
-    dom_path~ : @immut/array.T[UInt],
+    coord~ : @immut/vector.Vector[RespoCoord],
+    dom_path~ : @immut/vector.Vector[UInt],
     add~ : @hashset.HashSet[RespoEventType],
     remove~ : @hashset.HashSet[RespoEventType]
   )
   Effect(
-    coord~ : @immut/array.T[RespoCoord],
-    dom_path~ : @immut/array.T[UInt],
+    coord~ : @immut/vector.Vector[RespoCoord],
+    dom_path~ : @immut/vector.Vector[UInt],
     effect_type~ : RespoEffectType,
     skip_indexes~ : @hashset.HashSet[Int]
   )
@@ -163,8 +163,8 @@ enum ChildDomOp[T, G] {
   Append(RespoIndexKey, RespoNode[T, G])
   Prepend(RespoIndexKey, RespoNode[T, G])
   NestedEffect(
-    nested_coord~ : @immut/array.T[RespoCoord],
-    nested_dom_path~ : @immut/array.T[UInt],
+    nested_coord~ : @immut/vector.Vector[RespoCoord],
+    nested_dom_path~ : @immut/vector.Vector[UInt],
     effect_type~ : RespoEffectType,
     skip_indexes~ : @hashset.HashSet[Int]
   )
@@ -215,7 +215,7 @@ pub fn[T, G] ChildDomOp::to_cirru(self : ChildDomOp[T, G]) -> Cirru {
 ///|
 pub fn[T, G] DomChange::get_dom_path(
   self : DomChange[T, G],
-) -> @immut/array.T[UInt] {
+) -> @immut/vector.Vector[UInt] {
   match self {
     ReplaceElement(dom_path~, ..) => dom_path
     ModifyChildren(dom_path~, ..) => dom_path
@@ -235,13 +235,13 @@ pub fn RespoCoord::to_cirru(self : RespoCoord) -> Cirru {
 }
 
 ///|
-pub fn coord_path_to_cirru(coord : @immut/array.T[RespoCoord]) -> Cirru {
+pub fn coord_path_to_cirru(coord : @immut/vector.Vector[RespoCoord]) -> Cirru {
   let items = coord.map(fn(x) { x.to_cirru() })
   List(items.to_array())
 }
 
 ///|
-pub fn dom_path_to_cirru(dom_path : @immut/array.T[UInt]) -> Cirru {
+pub fn dom_path_to_cirru(dom_path : @immut/vector.Vector[UInt]) -> Cirru {
   let items = dom_path.map(fn(x) { Cirru::Leaf(x.to_string()) })
   List(items.to_array())
 }

--- a/src/node/element.mbt
+++ b/src/node/element.mbt
@@ -54,14 +54,14 @@ pub impl[T, G] Eq for RespoElement[T, G] with equal(
   // do not compare the function itself
   for pair in self.event {
     let (key, _value) = pair
-    if not(other.event.contains(key)) {
+    if !other.event.contains(key) {
       return false
     }
   }
-  if not(self.style == other.style) {
+  if !(self.style == other.style) {
     return false
   }
-  if not(self.children == other.children) {
+  if !(self.children == other.children) {
     return false
   }
   true

--- a/src/node/listener.mbt
+++ b/src/node/listener.mbt
@@ -45,7 +45,7 @@ pub impl Show for RespoEvent with output(self, logger) {
 /// Represents an event mark with its location in the virtual DOM tree.
 /// Contains the coordinate path to the element, the event type, and the event data.
 pub(all) struct RespoEventMark {
-  coord : @immut/array.T[RespoCoord]
+  coord : @immut/vector.Vector[RespoCoord]
   name : RespoEventType
   event_info : RespoEvent
 }

--- a/src/node/moon.pkg
+++ b/src/node/moon.pkg
@@ -4,7 +4,7 @@ import {
   "tiye/respo_css" @css,
   "moonbitlang/core/json" @json,
   "moonbitlang/core/hashset" @hashset,
-  "moonbitlang/core/immut/array" @immut/array,
+  "moonbitlang/core/immut/vector" @immut/vector,
   "moonbitlang/core/ref" @ref,
 }
 

--- a/src/node/node.mbt
+++ b/src/node/node.mbt
@@ -100,7 +100,7 @@ pub fn[T, G] load_coord_target_tree(
 /// creates a DOM tree from virtual DOM with proxied event handler attached
 pub fn[T, G] build_dom_tree(
   tree : RespoNode[T, G],
-  coord : @immut/array.T[RespoCoord],
+  coord : @immut/vector.Vector[RespoCoord],
   handle_event : (RespoEventMark) -> Unit raise RespoCommonError,
 ) -> @dom_ffi.Node raise RespoCommonError {
   let window = @dom_ffi.window()
@@ -136,16 +136,16 @@ pub fn[T, G] build_dom_tree(
             }
           _ =>
             if key.has_prefix("data-") {
-              element.set_data_attribute((try! key[5:]).to_string(), value)
+              element.set_data_attribute(key[5:].to_owned(), value)
             } else {
               element.set_attribute(key, value)
             }
         }
       }
-      if not(style.is_empty()) {
+      if !style.is_empty() {
         element.set_attribute("style", style.to_string())
       }
-      if inner_set && not(children.is_empty()) {
+      if inner_set && !children.is_empty() {
         @dom_ffi.warn_log(
           "innerText or innerHTML is set, it's conflicted with children: \{inner_set} {TODO children}",
         )

--- a/src/node/patch.mbt
+++ b/src/node/patch.mbt
@@ -35,7 +35,7 @@ pub fn[T, G] patch_tree(
               Component(left) => {
                 let { effects, .. } = left
                 for idx, effect in effects.iter2() {
-                  if not(skip_indexes.contains(idx)) {
+                  if !skip_indexes.contains(idx) {
                     let f = effect.handler
                     f(effect_type, target)
                     // TODO
@@ -89,7 +89,7 @@ pub fn[T, G] patch_tree(
                 name => raise RespoCommonError("unsupported value for:" + name)
               }
             } else if k.has_prefix("data-") {
-              el.set_data_attribute((try! k[5:]).to_string(), v)
+              el.set_data_attribute(k[5:].to_owned(), v)
             } else {
               el.set_attribute(k, v)
             }
@@ -102,11 +102,11 @@ pub fn[T, G] patch_tree(
             } else if k == "value" {
               let input_el = el.reinterpret_as_html_input_element()
               let prev_value = input_el.value()
-              if not(prev_value.is_empty()) {
+              if !prev_value.is_empty() {
                 input_el.set_value("")
               }
             } else if k.has_prefix("data-") {
-              el.remove_data_attribute((try! k[5:]).to_string())
+              el.remove_data_attribute(k[5:].to_owned())
             } else {
               el.remove_attribute(k)
             }
@@ -224,7 +224,7 @@ pub fn[T, G] patch_tree(
                 match target_tree {
                   Component({ effects, .. }) =>
                     for idx, effect in effects {
-                      if not(skip_indexes.contains(idx)) {
+                      if !skip_indexes.contains(idx) {
                         let f = effect.handler
                         f(effect_type, nested_el)
                       }
@@ -251,7 +251,7 @@ pub fn[T, G] patch_tree(
           match target_tree {
             Component({ effects, .. }) =>
               for idx, effect in effects {
-                if not(skip_indexes.contains(idx)) {
+                if !skip_indexes.contains(idx) {
                   let f = effect.handler
                   f(effect_type, target)
                 }
@@ -291,7 +291,7 @@ fn find_coord_dom_target(
 pub fn attach_event(
   element : @dom_ffi.Element,
   key : RespoEventType,
-  coord : @immut/array.T[RespoCoord],
+  coord : @immut/vector.Vector[RespoCoord],
   handle_event : (RespoEventMark) -> Unit raise RespoCommonError,
 ) -> Unit raise RespoCommonError {
   // @dom_ffi.log("attach event: " + key.to_string())

--- a/src/node/util.mbt
+++ b/src/node/util.mbt
@@ -9,7 +9,7 @@ fn[T : Eq + Hash] hashset_eq(
     return false
   }
   for x in xs {
-    if not(ys.contains(x)) {
+    if !ys.contains(x) {
       return false
     }
   }

--- a/src/renderer.mbt
+++ b/src/renderer.mbt
@@ -16,7 +16,7 @@ fn drain_rerender_status() -> Bool {
 ///|
 pub fn mark_need_rerender() -> Unit {
   let ret = need_to_rerender.val
-  if not(ret) {
+  if !ret {
     need_to_rerender.val = true
     // @dom_ffi.warn_log("mark need rerender")
   }
@@ -52,14 +52,14 @@ pub fn[T, U : Eq, G] render_node(
     // )
     mark_need_rerender()
   }
-  let element = @node.build_dom_tree(tree0, @immut/array.new(), handle_event)
+  let element = @node.build_dom_tree(tree0, @immut/vector.new(), handle_event)
 
   // collection mounted effects
   let mount_changes : Ref[Array[@node.DomChange[T, G]]] = Ref::new([])
   @node.collect_effects_outside_in_as(
     tree0,
-    @immut/array.new(),
-    @immut/array.new(),
+    @immut/vector.new(),
+    @immut/vector.new(),
     Mounted,
     mount_changes,
   )
@@ -91,8 +91,8 @@ pub fn[T, U : Eq, G] render_node(
       @node.diff_tree(
         new_tree,
         prev_tree.val,
-        @immut/array.new(),
-        @immut/array.new(),
+        @immut/vector.new(),
+        @immut/vector.new(),
         changes,
       )
       debug_render("\{changes.val.length()} DOM changes")
@@ -112,7 +112,7 @@ pub fn[T, U : Eq, G] render_node(
 fn[T, G] request_for_target_handler(
   tree : @node.RespoNode[T, G],
   event_name : @node.RespoEventType,
-  coord : @immut/array.T[@node.RespoCoord],
+  coord : @immut/vector.Vector[@node.RespoCoord],
 ) -> ((@node.RespoEvent, @node.DispatchFn[T]) -> Unit raise @node.RespoCommonError) raise @node.RespoCommonError {
   let target_node = @node.load_coord_target_tree(tree, coord.to_array())
   match target_node {

--- a/src/states-tree.mbt
+++ b/src/states-tree.mbt
@@ -24,7 +24,7 @@ pub(all) struct RespoStatesTree {
   priv data : ObscureState?
   backup : Json?
   /// the path to the current state in the tree, use in updating
-  cursor : @immut/array.T[String]
+  cursor : @immut/vector.Vector[String]
   branches : @immut/hashmap.HashMap[String, RespoStatesTree]
 }
 
@@ -33,7 +33,7 @@ pub impl Default for RespoStatesTree with default() {
   {
     data: None,
     backup: None,
-    cursor: @immut/array.new(),
+    cursor: @immut/vector.new(),
     branches: @immut/hashmap.new(),
   }
 }
@@ -126,7 +126,7 @@ pub impl @json.FromJson for RespoStatesTree with from_json(json, path) {
       {
         data: None,
         backup: @json.from_json(backup, path=path.add_key("backup")),
-        cursor: @immut/array.from_array(cursor_arr),
+        cursor: @immut/vector.from_array(cursor_arr),
         branches: @immut/hashmap.from_iter(branches_map.iter()),
       }
     }
@@ -234,7 +234,7 @@ pub fn RespoStatesTree::set_in(
   } else {
     // Use ArrayView slices and convert to Array for recursive call
     let p0 = change.cursor[0]
-    let p_rest = change.cursor[1:].to_array()
+    let p_rest = change.cursor[1:].to_owned()
     let branch = match self.branches.get(p0) {
       Some(existing) => existing.set_in({ ..change, cursor: p_rest })
       None => {


### PR DESCRIPTION
- Replace `immut/array` → `immut/vector` (package renamed)
- Replace `@immut/array.T` → `@immut/vector.Vector` (type renamed)
- Replace `not(x)` → `!x` (deprecated syntax)
- Replace `derive(Show)` with `derive(Debug)` + manual `Show` impl
- Replace `StringView/ArrayView .to_string()/.to_array()` with `.to_owned()`
- Remove unnecessary `try!` on string slice operations

Result: 0 warnings, 0 errors on `moon check --target js`